### PR TITLE
Fixed partitioned tables issue, bumps up jdbc version.

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -2,7 +2,7 @@
  ["src" "resources"]
 
  :deps
- {com.databricks/databricks-jdbc {:mvn/version "2.6.25-1"}}
+ {com.databricks/databricks-jdbc {:mvn/version "2.6.27"}}
 
  ;; build the driver with clojure -X:build
  :aliases

--- a/src/metabase/driver/databricks_sql.clj
+++ b/src/metabase/driver/databricks_sql.clj
@@ -94,7 +94,7 @@
                                                                       (dash-to-underscore table-name)))])]
        (set
         (for [[idx {col-name :col_name, data-type :data_type, :as result}] (m/indexed results)
-              :when (valid-describe-table-row? result)]
+              :while (valid-describe-table-row? result)]
           {:name              col-name
            :database-type     data-type
            :base-type         (sql-jdbc.sync/database-type->base-type :databricks-sql (keyword data-type))


### PR DESCRIPTION
This PR updates the JDBC driver to 2.6.27 and fixes a minor issue related to partitioned tables - it originally showed stray columns to the right of the schema with the naming following the describe table output (Part0, Part1), which broke the visual questions interface.