### PR TITLE
fix log4j issue

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 # Metabase Driver: Databricks SQL Warehouse
 
+This project is based on: 
+1. (Community Databricks Driver)[https://github.com/relferreira/metabase-sparksql-databricks-driver]
+2. (Databricks SparkSQL Driver) [https://github.com/metabase/metabase/blob/master/modules/drivers/sparksql]
+
 ## Installation
 
 Beginning with Metabase 0.32, drivers must be stored in a `plugins` directory in the same directory where `metabase.jar` is, or you can specify the directory by setting the environment variable `MB_PLUGINS_DIR`. There are a few options to get up and running with a custom driver.

--- a/bin/cli.sh
+++ b/bin/cli.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
-cp /driver/bin/deps.edn ~/.clojure/deps.edn
-cd /metabase
+#cp ./bin/deps.edn ~/.clojure/deps.edn
+cd ../metabase
 
 function nrepl() {
     clojure -M:user/databricks-sql:nrepl

--- a/deps.edn
+++ b/deps.edn
@@ -2,8 +2,7 @@
  ["src" "resources"]
 
  :deps
- {org.clojure.clr/core.logic {:mvn/version "1.0.1"}
-  com.databricks/databricks-jdbc {:mvn/version "2.6.34"}}
+ {com.databricks/databricks-jdbc {:mvn/version "2.6.34" :exclusion [log4j/log4j]}}
 
  ;; the stuff below is only for hacking on the driver locally and is not needed if you follow the instructions in the
  ;; README and create a `:local/root` dep for the driver and launch the REPL from the Metabase project rather than

--- a/src/metabase/driver/databricks_sql.clj
+++ b/src/metabase/driver/databricks_sql.clj
@@ -10,7 +10,6 @@
             [metabase.driver.sql.util :as sql.u]
             [metabase.driver.sql.util.unprepare :as unprepare]
             [metabase.mbql.util :as mbql.u]
-            [clojure.string :as str]
             [metabase.query-processor.util :as qp.util])
   (:import [java.sql Connection ResultSet]))
 
@@ -64,36 +63,20 @@
     #".*"               :type/*))
 
 
-;; 1.  databricks-sql doesn't support `.supportsTransactionIsolationLevel`
-;; 2.  databricks-sql doesn't support session timezones (at least our driver doesn't support it)
-;; 3.  databricks-sql doesn't support making connections read-only
-;; 4.  databricks-sql doesn't support setting the default result set holdability
-(defmethod sql-jdbc.execute/do-with-connection-with-options :databricks-sql
-  [driver db-or-id-or-spec options f]
-  (sql-jdbc.execute/do-with-resolved-connection 
-   driver
-   db-or-id-or-spec
-   options
-   (fn [^Connection conn]
-     (when-not (sql-jdbc.execute/recursive-connection?)
-       (.setTransactionIsolation conn Connection/TRANSACTION_READ_UNCOMMITTED))
-     (f conn))))
+(defmethod sql.qp/honey-sql-version :databricks-sql
+  [_driver]
+  2)
 
 ;; workaround for SPARK-9686 Spark Thrift server doesn't return correct JDBC metadata
 (defmethod driver/describe-database :databricks-sql
-  [driver database]
+  [_ database]
   {:tables
-   (sql-jdbc.execute/do-with-connection-with-options
-    driver
-    database
-    nil
-    (fn [^Connection conn]
-      (set
-       (for [{:keys [database tablename tab_name], table-namespace :namespace} (jdbc/query {:connection conn} ["show tables"])]
-         {:name   (or tablename tab_name) ; column name differs depending on server (databricks-sql, hive, Impala)
-          :schema (or (not-empty database)
-                      (not-empty table-namespace))}))))})
-
+   (with-open [conn (jdbc/get-connection (sql-jdbc.conn/db->pooled-connection-spec database))]
+     (set
+      (for [{:keys [database tablename], table-namespace :namespace} (jdbc/query {:connection conn} ["show tables"])]
+        {:name   tablename
+         :schema (or (not-empty database)
+                     (not-empty table-namespace))})))})
 
 ;; Hive describe table result has commented rows to distinguish partitions
 (defn- valid-describe-table-row? [{:keys [col_name data_type]}]
@@ -105,30 +88,25 @@
   (when s
     (str/replace s #"-" "_")))
 
-
 ;; workaround for SPARK-9686 Spark Thrift server doesn't return correct JDBC metadata
 (defmethod driver/describe-table :databricks-sql
   [driver database {table-name :name, schema :schema}]
   {:name   table-name
    :schema schema
    :fields
-   (sql-jdbc.execute/do-with-connection-with-options
-    driver
-    database
-    nil
-    (fn [^Connection conn]
-      (let [results (jdbc/query {:connection conn} [(format
-                                                     "describe %s"
-                                                     (sql.u/quote-name driver :table
-                                                                       (dash-to-underscore schema)
-                                                                       (dash-to-underscore table-name)))])]
-        (set
-         (for [[idx {col-name :col_name, data-type :data_type, :as result}] (m/indexed results)
-               :when (valid-describe-table-row? result)]
-           {:name              col-name
-            :database-type     data-type
-            :base-type         (sql-jdbc.sync/database-type->base-type :databricks-sql (keyword data-type))
-            :database-position idx})))))})
+   (with-open [conn (jdbc/get-connection (sql-jdbc.conn/db->pooled-connection-spec database))]
+     (let [results (jdbc/query {:connection conn} [(format
+                                                    "describe %s"
+                                                    (sql.u/quote-name driver :table
+                                                                      (dash-to-underscore schema)
+                                                                      (dash-to-underscore table-name)))])]
+       (set
+        (for [[idx {col-name :col_name, data-type :data_type, :as result}] (m/indexed results)
+              :while (valid-describe-table-row? result)]
+          {:name              col-name
+           :database-type     data-type
+           :base-type         (sql-jdbc.sync/database-type->base-type :databricks-sql (keyword data-type))
+           :database-position idx}))))})
 
 (def ^:dynamic *param-splice-style*
   "How we should splice params into SQL (i.e. 'unprepare' the SQL). Either `:friendly` (the default) or `:paranoid`.
@@ -151,6 +129,19 @@
         query       (assoc outer-query :native inner-query)]
     ((get-method driver/execute-reducible-query :sql-jdbc) driver query context respond)))
 
+;; 1.  SparkSQL doesn't support `.supportsTransactionIsolationLevel`
+;; 2.  SparkSQL doesn't support session timezones (at least our driver doesn't support it)
+;; 3.  SparkSQL doesn't support making connections read-only
+;; 4.  SparkSQL doesn't support setting the default result set holdability
+(defmethod sql-jdbc.execute/connection-with-timezone :databricks-sql
+  [driver database _timezone-id]
+  (let [conn (.getConnection (sql-jdbc.execute/datasource-with-diagnostic-info! driver database))]
+    (try
+      (.setTransactionIsolation conn Connection/TRANSACTION_READ_UNCOMMITTED)
+      conn
+      (catch Throwable e
+        (.close conn)
+        (throw e)))))
 
 ;; 1.  SparkSQL doesn't support setting holdability type to `CLOSE_CURSORS_AT_COMMIT`
 (defmethod sql-jdbc.execute/prepared-statement :databricks-sql


### PR DESCRIPTION
Previous version was logging:

ERROR StatusLogger Unable to create custom ContextSelector. Falling back to default.
java.lang.ClassCastException: Cannot cast org.apache.logging.log4j.core.selector.BasicContextSelector to com.databricks.client.jdbc42.internal.apache.logging.log4j.core.selector.ContextSelector

So I've decided to roll-back few mods and exclude log4j from mvn dependencies. 