### PR TITLE
use `close` made in the decorator

### DIFF
--- a/src/metabase/driver/databricks_sql.clj
+++ b/src/metabase/driver/databricks_sql.clj
@@ -1,20 +1,19 @@
 (ns metabase.driver.databricks-sql
   (:require [clojure.java.jdbc :as jdbc]
-            [clojure.string :as str]
+            [clojure.string :as string]
             [medley.core :as m]
             [metabase.driver :as driver]
-            [metabase.driver.sql-jdbc
-             [common :as sql-jdbc.common]]
+            [metabase.driver.sql-jdbc.common :as sql-jdbc.common]
             [metabase.driver.sql-jdbc.connection :as sql-jdbc.conn]
             [metabase.driver.sql-jdbc.execute :as sql-jdbc.execute]
             [metabase.driver.sql-jdbc.sync :as sql-jdbc.sync]
             [metabase.driver.sql.query-processor :as sql.qp]
             [metabase.driver.sql.util :as sql.u]
             [metabase.driver.sql.util.unprepare :as unprepare]
+            [metabase.util.log :as log]
             [metabase.legacy-mbql.util :as mbql.u]
             [metabase.query-processor.util :as qp.util])
-  (:import 
-   (java.sql Connection ResultSet)))
+  (:import [java.sql Connection ResultSet]))
 
 (set! *warn-on-reflection* true)
 
@@ -38,7 +37,7 @@
                               ";LogLevel=0"
                               ";UID=token"
                               ";PWD=" (:token details)
-                              ";httpPath=" (:http-path details))) 
+                              ";httpPath=" (:http-path details)))
       (select-keys [:host :db :jdbc-flags :dbname])
       sparksql-databricks
       (sql-jdbc.common/handle-additional-options details)))

--- a/src/metabase/driver/databricks_sql.clj
+++ b/src/metabase/driver/databricks_sql.clj
@@ -53,7 +53,7 @@
 
 (defmethod sql-jdbc.sync/database-type->base-type :databricks-sql
   [_ database-type]
-  (condp re-matches (str/lower-case (name database-type))
+  (condp re-matches (string/lower-case (name database-type))
     #"boolean"          :type/Boolean
     #"tinyint"          :type/Integer
     #"smallint"         :type/Integer
@@ -81,7 +81,7 @@
 
 (defn- dash-to-underscore [s]
   (when s
-    (str/replace s #"-" "_")))
+    (string/replace s #"-" "_")))
 
 ;; workaround for SPARK-9686 Spark Thrift server doesn't return correct JDBC metadata
 (defmethod driver/describe-database :databricks-sql
@@ -100,8 +100,8 @@
 
 ;; Hive describe table result has commented rows to distinguish partitions
 (defn- valid-describe-table-row? [{:keys [col_name data_type]}]
-  (every? (every-pred (complement str/blank?)
-                      (complement #(str/starts-with? % "#")))
+  (every? (every-pred (complement string/blank?)
+                      (complement #(string/starts-with? % "#")))
           [col_name data_type]))
 
 ;; workaround for SPARK-9686 Spark Thrift server doesn't return correct JDBC metadata


### PR DESCRIPTION
we implemented it, but it was not being used
it will not solve the issue of keeping the connection open described in issue #13, but it keeps the JDBC implementation organized

depends: #14